### PR TITLE
Publish build artifacts as GitHub releases

### DIFF
--- a/.github/workflows/on-main-push.yml
+++ b/.github/workflows/on-main-push.yml
@@ -10,9 +10,58 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      version_tag: ${{ steps.version.outputs.version_tag }}
+    steps:
+      - name: Generate version tag
+        id: version
+        run: echo "version_tag=$(TZ=Asia/Tokyo date +'%Y%m%d.%H%M%S')" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: version
     uses: ./.github/workflows/wf-build.yml
+    with:
+      version_tag: ${{ needs.version.outputs.version_tag }}
 
   build-container:
+    needs: version
     uses: ./.github/workflows/wf-build-container.yml
+    with:
+      version_tag: ${{ needs.version.outputs.version_tag }}
+
+  release:
+    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    needs:
+      - version
+      - build
+      - build-container
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@95815c38cf14ee0e1db257ec2f16f369c7d6955b # v4.2.1
+        with:
+          path: dist
+          pattern: cloudflare-ddns-${{ needs.version.outputs.version_tag }}-*
+          merge-multiple: true
+
+      - name: Generate checksums
+        working-directory: dist
+        run: sha256sum cloudflare-ddns-* > SHA256SUMS
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION_TAG: ${{ needs.version.outputs.version_tag }}
+        run: |
+          gh release create "$VERSION_TAG" dist/cloudflare-ddns-* dist/SHA256SUMS \
+            --generate-notes \
+            --latest \
+            --target "$GITHUB_SHA" \
+            --title "$VERSION_TAG"

--- a/.github/workflows/wf-build-container.yml
+++ b/.github/workflows/wf-build-container.yml
@@ -8,6 +8,10 @@ on:
         type: boolean
         required: false
         default: true
+      version_tag:
+        description: Release version tag used for image tags
+        type: string
+        required: false
   workflow_call:
     inputs:
       push:
@@ -15,6 +19,11 @@ on:
         type: boolean
         required: false
         default: true
+      version_tag:
+        description: Release version tag used for image tags
+        type: string
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -45,7 +54,7 @@ jobs:
           images: ghcr.io/rokoucha/cloudflare-ddns
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
-            type=raw,value={{date 'YYYYMMDD.HHmmss' tz='Asia/Tokyo'}},enable={{is_default_branch}}
+            type=raw,value=${{ inputs.version_tag }},enable=${{ inputs.version_tag != '' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
             type=ref,event=pr
             type=sha
 

--- a/.github/workflows/wf-build.yml
+++ b/.github/workflows/wf-build.yml
@@ -8,6 +8,10 @@ on:
         type: boolean
         required: false
         default: true
+      version_tag:
+        description: Release version tag used for artifacts
+        type: string
+        required: false
   workflow_call:
     inputs:
       push:
@@ -15,6 +19,11 @@ on:
         type: boolean
         required: false
         default: true
+      version_tag:
+        description: Release version tag used for artifacts
+        type: string
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -44,13 +53,14 @@ jobs:
         run: go mod download
 
       - name: Build
-        run: go build -o ./cloudflare-ddns$X
+        run: go build -o "./${OUTPUT_NAME}"
         env:
           GOARCH: ${{ matrix.GOARCH }}
           GOOS: ${{ matrix.GOOS }}
+          OUTPUT_NAME: cloudflare-ddns-${{ matrix.GOOS }}-${{ matrix.GOARCH }}
 
       - name: Upload build result
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: cloudflare-ddns-${{ matrix.GOOS }}-${{ matrix.GOARCH }}
-          path: cloudflare-ddns
+          name: cloudflare-ddns-${{ inputs.version_tag != '' && format('{0}-', inputs.version_tag) || '' }}${{ matrix.GOOS }}-${{ matrix.GOARCH }}
+          path: cloudflare-ddns-${{ matrix.GOOS }}-${{ matrix.GOARCH }}


### PR DESCRIPTION
Create a shared timestamp tag for release assets and container images, publish binaries with checksums to GitHub Releases, and reuse the same tag for GHCR images.